### PR TITLE
Hotfix: Add missing plugin repository

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -116,7 +116,7 @@ libraryPath("${project.rootDir.absolutePath}/project/projectname.gdnlib")
 \
 Now we need to specify the output folder for the generated `.gdns` files:
 ```kotlin
-generateGDNS("${project.rootDir.absolutePath}/project")
+generateGDNS("${project.rootDir.absolutePath}/../project")
 ```
 
 \
@@ -202,7 +202,7 @@ kotlin {
                 }
 
                 libraryPath("${project.rootDir.absolutePath}/project/projectname.gdnlib")
-                generateGDNS("${project.rootDir.absolutePath}/project")
+                generateGDNS("${project.rootDir.absolutePath}/../project")
                 
                 configs(
                         

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -50,6 +50,7 @@ Inside your `build.gradle.kts` file, you need to define the `godot-gradle-plugin
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -66,6 +67,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 
@@ -160,6 +162,7 @@ If you followed along your `build.gradle.kts` file should look like this:
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -176,6 +179,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
                 }
 
                 libraryPath("coroutines.gdnlib")
-                generateGDNS("${project.rootDir.absolutePath}/project")
+                generateGDNS("${project.rootDir.absolutePath}/../project")
 
                 configs(
                         "src/main/kotlin/godot/samples/coroutines/classes.json"

--- a/samples/coroutines/kotlin/build.gradle.kts
+++ b/samples/coroutines/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -11,6 +12,7 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
                 }
 
                 libraryPath("samples.gdnlib")
-                generateGDNS("${project.rootDir.absolutePath}/project")
+                generateGDNS("${project.rootDir.absolutePath}/../project")
 
                 configs(
                         "src/main/kotlin/godot/samples/games/shmup/classes.json",

--- a/samples/games/kotlin/build.gradle.kts
+++ b/samples/games/kotlin/build.gradle.kts
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
         jcenter()
     }
     dependencies {
@@ -17,6 +18,7 @@ apply(plugin = "godot-gradle-plugin")
 
 repositories {
     mavenLocal()
+    maven("https://dl.bintray.com/utopia-rise/kotlin-godot")
     jcenter()
 }
 


### PR DESCRIPTION
This hotfix fixes the following:
- Adds missing plugin repository maven url
- Fixes wrong output path for generated gdns files

Resolves #5 